### PR TITLE
Added vector<vector<Link>> to the the python wrapper to be able to 

### DIFF
--- a/interfaces/SequenceGraph.i.in
+++ b/interfaces/SequenceGraph.i.in
@@ -93,6 +93,7 @@ namespace std {
    %template(vectorFloat) vector<float>;
    %template(vectorString) vector<string>;
    %template(vectorLink) vector<Link>;
+   %template(vectorvectorLink) vector<vector<Link>>;
    %template(vectorSGNode) vector<sgNodeID_t>;
    %template(vectorvectorSGNode) vector<vector<sgNodeID_t>>;
    %template(vectorNode) vector<Node>;


### PR DESCRIPTION
use the depth parameter in the export gfa function